### PR TITLE
Bump copyright year to current year

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -92,7 +92,7 @@ Renee Baecker <reneeb@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is Copyright (c) 2015 by Renee Baecker.
+This software is Copyright (c) 2021 by Renee Baecker.
 
 This is free software, licensed under:
 

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Algorithm-Diff-HTMLTable
 author  = Renee Baecker <reneeb@cpan.org>
 license = Artistic_2_0
 copyright_holder = Renee Baecker
-copyright_year   = 2015
+copyright_year   = 2021
 
 [Git::Contributors]
 include_authors = 1


### PR DESCRIPTION
Hi Renee!

I know that the last release was from 2018, but since I plan to add a few more PRs, my guess is that the next release will be in 2021, hence why I set the copyright year to 2021.  :-)  If you'd rather that I set it to 2018, please let me know and I'll update the PR as necessary.

Viele Grüße,

Paul