### PR TITLE
Set minimum Perl version explicitly

### DIFF
--- a/lib/Algorithm/Diff/HTMLTable.pm
+++ b/lib/Algorithm/Diff/HTMLTable.pm
@@ -5,6 +5,8 @@ package Algorithm::Diff::HTMLTable;
 use strict;
 use warnings;
 
+use 5.010;
+
 use Algorithm::Diff;
 use Carp;
 use HTML::Entities;


### PR DESCRIPTION
The tool `perlver` showed that no minimum Perl version was set
explicitly.  `perlver` showed that the main module file used syntax
which is required as of Perl 5.10, hence the minimum version has been
set to this version number.