### PR TITLE
Add initial GitHub actions config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,29 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  perl_tester:
+    runs-on: 'ubuntu-latest'
+    name: "perl v${{ matrix.perl-version }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - "5.30"
+          - "5.28"
+          - "5.26"
+          - "5.24"
+          - "5.22"
+          - "5.20"
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cpanm --notest Dist::Zilla
+      - run: dzil authordeps --missing | cpanm
+      - run: dzil listdeps --author --missing | cpanm
+      - run: dzil test --author --release


### PR DESCRIPTION
Now that GitHub has its own CI/CD solution (and Travis restricts how many CPU credits one is allowed to use), it makes sense to run the test suite through GitHub actions.  This PR adds an initial, working configuration to build and test the dist on GitHub.